### PR TITLE
Fix visualization audio desync for footsteps

### DIFF
--- a/scripts/simquery.lua
+++ b/scripts/simquery.lua
@@ -61,3 +61,10 @@ function simquery.canSoftPath(sim, unit, startcell, endcell, ...)
 
     return simquery.canStaticPath(sim, unit, startcell, endcell)
 end
+
+-- Fix for client audio not respecting the unit's dashSoundRange, causing desync between visuals and audio
+-- extremely simple fix thanks to Sim Constructor's agentrig override. Check SC's simquery.lua for reference
+local simquery = include("sim/simquery")
+function simquery.getMoveAudioRange(unit, cell)
+    return simquery.getMoveSoundRange(unit, cell)
+end

--- a/scripts/simquery.lua
+++ b/scripts/simquery.lua
@@ -64,7 +64,6 @@ end
 
 -- Fix for client audio not respecting the unit's dashSoundRange, causing desync between visuals and audio
 -- extremely simple fix thanks to Sim Constructor's agentrig override. Check SC's simquery.lua for reference
-local simquery = include("sim/simquery")
 function simquery.getMoveAudioRange(unit, cell)
     return simquery.getMoveSoundRange(unit, cell)
 end


### PR DESCRIPTION
Not much to say about this one; Sim Constructor pretty much already did all of the work. Cyberboy was hesitant to change vanilla behaviour so SC's simquery.getMoveAudioRange currently only calls simquery.getMoveSoundRange when the dashSoundRange has been modified to allow mods to modify it. Feel free to make this dependant on an option