### PR TITLE
Fix observePath ability not respecting vision gained from camera canisters, turrets etc.

### DIFF
--- a/scripts/abilities/observePath.lua
+++ b/scripts/abilities/observePath.lua
@@ -1,0 +1,22 @@
+-- Fix observePath ability not respecting vision gained from camera canisters, turrets etc.
+-- Check all PC units that have hasSight and are not agents or eyeballs
+local array = include("modules/array")
+local abilitydefs = include("sim/abilitydefs")
+local observePath = abilitydefs.lookupAbility("observePath")
+
+local origAquireTargets = observePath.acquireTargets
+function observePath:acquireTargets(targets, game, sim, unit, userUnit, ...)
+    local unitTarget = origAquireTargets(self, targets, game, sim, unit, userUnit, ...)
+    for _, targetUnit in pairs(sim:getAllUnits()) do
+        if self:isTarget(unitTarget._abilityUser, targetUnit) and not array.find(unitTarget._units, targetUnit) then
+            for _, seerUnit in pairs(sim:getPC():getUnits()) do
+                if not (seerUnit:getTraits().isAgent or seerUnit:getTraits().peekID) and seerUnit:getTraits().hasSight and
+                    sim:canUnitSeeUnit(seerUnit, targetUnit) then
+                    table.insert(unitTarget._units, targetUnit)
+                    break
+                end
+            end
+        end
+    end
+    return unitTarget
+end

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -138,6 +138,7 @@ local function init(modApi)
     include(scriptPath .. "/abilities/peek")
     include(scriptPath .. "/abilities/prime_emp")
     include(scriptPath .. "/abilities/scandevice")
+    include(scriptPath .. "/abilities/observePath")
 
     local fnlib = findModByName("Function Library")
     if not fnlib then


### PR DESCRIPTION
Fix #56 
Append ``observePath:acquireTargets`` to include all units seen by PC units that aren't agents or eyeballs. This is pretty inclusive, but currently I don't see a problem with that.