### PR TITLE
Overwatch fixes

### DIFF
--- a/scripts/abilities/shootOverwatch.lua
+++ b/scripts/abilities/shootOverwatch.lua
@@ -1,0 +1,14 @@
+-- do not execute shootOverwatch if guard started aiming during the very same PC action.
+-- trait set in aiplayer.tickBrain
+
+local abilitydefs = include("sim/abilitydefs")
+local shootOverwatch = abilitydefs.lookupAbility("shootOverwatch")
+
+local origExecuteAbility = shootOverwatch.executeAbility
+function shootOverwatch:executeAbility(sim, unit, userUnit, targetUnit, ...)
+    if userUnit:getTraits()._cbf_aim_id == sim:getActionCount() then
+        return
+    end
+    origExecuteAbility(self, sim, unit, userUnit, targetUnit, ...)
+    sim:processReactions(userUnit) -- issue #19 
+end

--- a/scripts/abilities/shootOverwatch.lua
+++ b/scripts/abilities/shootOverwatch.lua
@@ -4,11 +4,16 @@
 local abilitydefs = include("sim/abilitydefs")
 local shootOverwatch = abilitydefs.lookupAbility("shootOverwatch")
 
-local origExecuteAbility = shootOverwatch.executeAbility
-function shootOverwatch:executeAbility(sim, unit, userUnit, targetUnit, ...)
+local origOnTrigger = shootOverwatch.onTrigger
+function shootOverwatch:onTrigger(sim, evType, evData, userUnit, ...)
     if userUnit:getTraits()._cbf_aim_id == sim:getActionCount() then
         return
     end
+    origOnTrigger(self, sim, evType, evData, userUnit, ...)
+end
+
+local origExecuteAbility = shootOverwatch.executeAbility
+function shootOverwatch:executeAbility(sim, unit, userUnit, targetUnit, ...)
     origExecuteAbility(self, sim, unit, userUnit, targetUnit, ...)
     sim:processReactions(userUnit) -- issue #19 
 end

--- a/scripts/aiplayer.lua
+++ b/scripts/aiplayer.lua
@@ -1,0 +1,28 @@
+local aiplayer = include("sim/aiplayer")
+
+-- part of overwatch fixes
+-- sim_cbf_movingUnit is set in simengine.moveUnit
+-- unit:getTraits()._cbf_aim_id is checked in shootOverwatch.executeAbility
+
+-- probably safer so set our own tracker instead of checking for the movePath trait in case some mod messes with it
+local origTickBrain = aiplayer.tickBrain
+function aiplayer:tickBrain(unit)
+    local wasAiming = unit:isAiming()
+    local thought = origTickBrain(self, unit)
+    if not wasAiming and unit:isAiming() and self._sim:getCurrentPlayer():isPC() then
+        unit:getTraits()._cbf_aim_id = self._sim:getActionCount()
+    end
+    return thought
+end
+
+-- if unit is still in the process of moving, do not tick brains unless processing reactions to the moving unit.
+-- might also need to intercept if no sourceUnit is given, but haven't found the need to so far.
+local origProcessReactions = aiplayer.processReactions
+function aiplayer:processReactions(sourceUnit)
+    local movingUnit = self._sim._cbf_movingUnit
+    if movingUnit and sourceUnit and movingUnit ~= sourceUnit and movingUnit:canAct() and
+        not movingUnit:getTraits().interrupted then
+        return
+    end
+    origProcessReactions(self, sourceUnit)
+end

--- a/scripts/engine.lua
+++ b/scripts/engine.lua
@@ -158,7 +158,11 @@ function simengine:moveUnit(unit, moveTable, ...)
         self:cbfStartPathingQueue()
     end
 
+    self._cbf_movingUnit = unit
+
     local canMoveReason, end_cell = oldMoveUnit(self, unit, moveTable, ...)
+
+    self._cbf_movingUnit = nil
 
     if usePathingQueue then
         self:cbfProcessPathingQueue()

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -102,6 +102,7 @@ local function init(modApi)
 
     include(scriptPath .. "/simplayer")
     include(scriptPath .. "/pcplayer")
+    include(scriptPath .. "/aiplayer")
 
     include(scriptPath .. "/hud")
     include(scriptPath .. "/hunt")
@@ -138,6 +139,7 @@ local function init(modApi)
     include(scriptPath .. "/abilities/peek")
     include(scriptPath .. "/abilities/prime_emp")
     include(scriptPath .. "/abilities/scandevice")
+    include(scriptPath .. "/abilities/shootOverwatch")
 
     local fnlib = findModByName("Function Library")
     if not fnlib then

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -21,7 +21,7 @@ local function earlyInit(modApi)
         -- Escorts Fixed patches upvalues in mission_scoring.
         -- This needs to be done before any normal wrapping of the library.
         "Escorts Fixed", -- Items Evacutation overwrites the "escape" ability.
-        "Items Evacuation", -- AGP overwrites Senses:addInterest, line_of_sight:calculateUnitLOS.
+        "Items Evacuation", -- AGP overwrites Senses:addInterest, line_of_sight:calculateUnitLOS, aiplayer:tickBrain
         "Advanced Guard Protocol",
         -- Talkative Agents adds event handlers to mission_panel:processEvent in lateInit.
         "Talkative Agents",


### PR DESCRIPTION
For overwatch bugs, the single cause I have found for all bugs of a unit shooting/not shooting when appropriate is the interaction between aiplayer:tickBrain(nonActingUnit) and sim:processReactions(actingUnit) during an action that runs sim:processReactions(actingUnit) at the end of it.

**A guard shooting when not appropriate (Fix #32):**

Example 1: A guard waking up from KO from a Jolt from Monst3ers gun gets its brain ticked during its ``processReactions(awakeningGuard)`` call in ``simunit.tickKo`` before ``processReactions(monst3er)`` runs, causing the guard to update its senses, think and start aiming at monster first and then him getting shot immediately after during monst3er's ``processReactions``.

Example 2: PE extended alarm level 4 is similar: During an action with ``processReaction(actingUnit)`` at the end of it, the alarm level can get increased, which ``aiplayer.onTrigger`` reacts to by ticking all brains, causing a guard to be able to start aiming at the acting unit and then shoot it when its ``processReaction`` runs.

Fix: If a guard has started aiming at an agent as a result of ``tickBrain`` during pc turn, do not let it fire in the same sim action. Store the current sim action count on the aiming unit to track during which action it has started aiming. Append ``tickBrain`` because it is the cause of the bugs and ``simunit.setAiming`` might get called by mods to run custom logic with overwatch.
```lua
local aiplayer = include("sim/aiplayer")

local origTickBrain = aiplayer.tickBrain
function aiplayer:tickBrain(unit)
    local wasAiming = unit:isAiming()
    local thought = origTickBrain(self, unit)
    if not wasAiming and unit:isAiming() and self._sim:getCurrentPlayer():isPC() then
        unit:getTraits()._cbf_aim_id = self._sim:getActionCount()
    end
    return thought
end

-- do not execute shootOverwatch if guard started aiming during the very same PC action.
-- trait set in aiplayer.tickBrain

local abilitydefs = include("sim/abilitydefs")
local shootOverwatch = abilitydefs.lookupAbility("shootOverwatch")

local origOnTrigger = shootOverwatch.onTrigger
function shootOverwatch:onTrigger(sim, evType, evData, userUnit, ...)
    if userUnit:getTraits()._cbf_aim_id == sim:getActionCount() then
        return
    end
    origOnTrigger(self, sim, evType, evData, userUnit, ...)
end

local origExecuteAbility = shootOverwatch.executeAbility
function shootOverwatch:executeAbility(sim, unit, userUnit, targetUnit, ...)
    origExecuteAbility(self, sim, unit, userUnit, targetUnit, ...)
    sim:processReactions(userUnit) -- issue #19 
end
```

PE Terminate subroutine immediately fires on tickBrain before the trait can get set.
AGP skipOverwatch uses shootSingle instead, NEP seekers use a completely custom action.
Not sure what other cases to check for this, everything worked so far.

Also fix #19 while we're at it (I haven't tested this fix much yet though). 

(I am tempted to remove the sim:getCurrentPlayer():isPC() checks to stop stuff like an agent waking up after getting KO'd from doorkick only to get immediately shot on player turn start or guards reacting to ambushes by the player during the enemy turn after they just started aiming, but these are arguably not bugs)

**Missing reaction to a moving unit (Fix #42 + guards not shooting agents when warp caused another guard to turn)**:

Example 1: Guards not shooting agents when movement caused another guard to turn (https://discord.com/channels/313015356052471828/313015598789427202/1382774025570488461):
``Senses:processWarpTrigger`` can call ``unit.turnToFace``, which calls ``unit.updateFacing``, which calls ``sim.processReactions(turningGuard)``, which is causing the turning guard's brain to tick, causing him to react to the agent (interrupting them) before ``movingAgent.interrupted`` in ``sim.moveunit`` is checked, which causes the agent's own ``processReactions`` to not be reached and the already aiming guard not to shoot.

Example 2: Ambushing and disguised prism behind door not reacting to a moving guard correctly when her disguise breaks:
Same thing applies here. the guard's brain gets ticked by ``processReactions(Prism)`` from her disguise fading from the guard's modifyExit or warpUnit, interrupting its own movement before its moveUnit code reaches the ``movingGuard.interrupted`` trait check and ``processReactions(movingGuard)`` can run.

Fixing this is a bit trickier. At first I tried suppressing tickBrain while a moving unit is warping, but that only works for warp triggers and not for e.g. modifyExit.
All misplaced brain ticks are caused by a ``processReactions(nonMovingUnit)`` during a move, so instead, intercept ``aiplayer.processReactions`` (not ``sim.processReactions`` to still allow overwatch triggers) before it can tick brains for these cases.

```lua
-- probably safer so set our own tracker instead of checking for the movePath trait in case some mod messes with it
local simengine = include("sim/engine")
local origMoveUnit = simengine.moveUnit
function simengine:moveUnit(unit, ...)
    self._cbf_movingUnit = unit
    local canMoveReason, end_cell = origMoveUnit(self, unit, ...)
    self._cbf_movingUnit = nil
    return canMoveReason, end_cell
end

-- if unit is still in the process of moving, do not tick brains unless processing reactions to the mover.
-- might also need to intercept if no sourceUnit is given, but haven't found the need to so far.
local origProcessReactions = aiplayer.processReactions
function aiplayer:processReactions(sourceUnit)
    local movingUnit = self._sim._cbf_movingUnit
    if movingUnit and sourceUnit and movingUnit ~= sourceUnit and movingUnit:canAct() and
        not movingUnit:getTraits().interrupted then
        return
    end
    origProcessReactions(self, sourceUnit)
end
```