### PR TITLE
Accidental globals + endless lootweight fix + missing rewind prompt

### DIFF
--- a/scripts/abilities/activate_locked_console.lua
+++ b/scripts/abilities/activate_locked_console.lua
@@ -5,7 +5,7 @@ local abilityutil = include("sim/abilities/abilityutil")
 
 local cbf_util = include(SCRIPT_PATHS.qoala_commbugfix .. "/cbf_util")
 
-function hasSecurityChip(sim, abilityOwner, unit)
+local function hasSecurityChip(sim, abilityOwner, unit)
     if cbf_util.simCheckFlag(sim, "cbf_ending_finaldoor") then
         for i, item in ipairs(unit:getChildren()) do
             if item:getTraits().finalAugmentKey then

--- a/scripts/cbf_util.lua
+++ b/scripts/cbf_util.lua
@@ -1,4 +1,4 @@
-_M = {}
+local _M = {}
 
 -- Check if a flag is enabled on the sim
 function _M.simCheckFlag(sim, flag, default)

--- a/scripts/items_panel.lua
+++ b/scripts/items_panel.lua
@@ -10,7 +10,7 @@ local pickup_panel = items_panel.pickup
 
 local oldLootRefreshItem = loot_panel.refreshItem
 
-function getCarryableItemByIndex(unit, targetUnit, i)
+local function getCarryableItemByIndex(unit, targetUnit, i)
     for _, childUnit in ipairs(targetUnit:getChildren()) do
         if (not childUnit:getTraits().augment or not childUnit:getTraits().installed) and
                 inventory.canCarry(unit, childUnit) then

--- a/scripts/missions/escape_mission.lua
+++ b/scripts/missions/escape_mission.lua
@@ -2,7 +2,7 @@
 local cbf_util = include(SCRIPT_PATHS.qoala_commbugfix .. "/cbf_util")
 local constants = include(SCRIPT_PATHS.qoala_commbugfix .. "/constants")
 
-function initFoundPrisoner(sim)
+local function initFoundPrisoner(sim)
     if sim:getParams().foundPrisoner == nil then
         local spawnAgentOption = cbf_util.simCheckFlag(sim, "cbf_detention_spawnagent")
         if spawnAgentOption == constants.MISSIONDETCENTER_SPAWNAGENT.FIRSTAGENT or spawnAgentOption ==
@@ -15,7 +15,7 @@ function initFoundPrisoner(sim)
     end
 end
 
-function init(scriptMgr, sim)
+local function init(scriptMgr, sim)
     initFoundPrisoner(sim)
 end
 

--- a/scripts/missions/mission_util.lua
+++ b/scripts/missions/mission_util.lua
@@ -1,0 +1,16 @@
+local mission_util = include("sim/missions/mission_util")
+local util = include("client_util")
+local simdefs = include("sim/simdefs")
+
+-- the viz handler for the event also checks for pc:isNeutralized.
+-- so simply retiring will not cause the prompt to appear
+local oldinit = mission_util.campaign_mission.init
+function mission_util.campaign_mission:init(scriptMgr, ...)
+	oldinit(self, scriptMgr, ...)
+	scriptMgr:addHook("CBF_GAMEOVER", function(script, sim)
+		script:waitFor(util.extend(mission_util.PC_LOST)({ priority = 1 }))
+		if sim:getTags().cbf_got_rewind_prompt ~= sim:getActionCount() then
+			sim:dispatchEvent(simdefs.EV_SHOW_MODAL_REWIND)
+		end
+	end, true)
+end

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -125,6 +125,8 @@ local function init(modApi)
     include(scriptPath .. "/units/cbf_smoke_edge")
     include(scriptPath .. "/units/simdisguiseitem")
     include(scriptPath .. "/units/smoke_cloud")
+    include(scriptPath .. "/missions/mission_util")
+	include(scriptPath .. "/procgen")
 
     -- Ability patches. (Abilities are NOT reloaded on load)
     include(scriptPath .. "/abilities/activate_final_console")

--- a/scripts/procgen.lua
+++ b/scripts/procgen.lua
@@ -1,0 +1,31 @@
+local procgen = include("sim/procgen")
+local mazegen = include("sim/mazegen")
+local array = include("modules/array")
+
+local function analyzeFeatures(cxt)
+	for _, room in ipairs(cxt.rooms) do
+		room.tags = room.tags or {}
+	end
+
+	local originRoom = array.findIf(cxt.rooms, function(r)
+		return r.tags ~= nil and r.tags.entry
+	end)
+
+	mazegen.breadthFirstSearch(cxt, originRoom, function(room)
+		room.lootWeight = (room.depth or 0) + 1
+	end)
+	local exitRoom = array.findIf(cxt.rooms, function(r)
+		return r.tags ~= nil and (r.tags.exit or r.tags.exit_vault) -- fix endless exit not being included
+	end)
+	if exitRoom then
+		mazegen.breadthFirstSearch(cxt, exitRoom, function(room)
+			room.lootWeight = room.lootWeight * ((room.depth or 0) + 1)
+		end)
+	end
+
+	for i, room in ipairs(cxt.rooms) do
+		cxt.maxLootWeight = math.max(room.lootWeight, cxt.maxLootWeight or 0)
+	end
+end
+
+upvalueUtil.findAndReplace(procgen.generateLevel, "analyzeFeatures", analyzeFeatures)

--- a/scripts/simunit.lua
+++ b/scripts/simunit.lua
@@ -166,6 +166,17 @@ function simunit:returnItemsToStash(sim)
     end
 end
 
+-- check if player already got a rewind prompt this action
+local oldonDamage = simunit.onDamage
+function simunit:onDamage(...)
+	local couldHaveBeenCritical = self:getTraits().canBeCritical
+	oldonDamage(self, ...)
+	local sim = self:getSim()
+	if couldHaveBeenCritical and sim:getPC():isNeutralized(sim) then
+		sim:getTags().cbf_got_rewind_prompt = sim:getActionCount()
+	end
+end
+
 -- ===
 
 local oldCreateUnit = simunit.createUnit

--- a/scripts/simunit.lua
+++ b/scripts/simunit.lua
@@ -170,8 +170,8 @@ end
 local oldonDamage = simunit.onDamage
 function simunit:onDamage(...)
 	local couldHaveBeenCritical = self:getTraits().canBeCritical
-	oldonDamage(self, ...)
 	local sim = self:getSim()
+	oldonDamage(self, ...)
 	if couldHaveBeenCritical and sim:getPC():isNeutralized(sim) then
 		sim:getTags().cbf_got_rewind_prompt = sim:getActionCount()
 	end


### PR DESCRIPTION
This PR is hopefully not touching anything you'd rather not implement in CBF this time and simple.
Fixing the accidental global declarations and the ``lootWeight`` not being calculated correctly for missions with the DLC exit is pretty self explanatory (debug mode lets you see the lootWeight of rooms in the procgen mode).
The other bug is the "Would you like to rewind?" prompt not showing when the game is over because all agents are pinned and so the player is not getting the chance to use their rewinds, if they have any left.
Making sure that it shows would also be simple if not for the case that we should make sure that it is not asked twice when it happens via the usual ``simunit.onDamage`` trigger. So, check if the current action already had a rewind prompt by letting ``simunit.onDamage`` set a sim tag with the current action count when its conditions are fulfilled. Listen to the same trigger as the vanilla mission game over hook (``mission_util.PC_LOST``), but set it to one priority above so it triggers first (default is 0).

I'm not sure if you'd prefer a combined PR like this or a seperate PR for each bug. I just tried it like this this time. I don't usually use github or do PRs so please tell me if I should do something better.