### PR TITLE
Crybaby + guards aiming at units out of range fix

### DIFF
--- a/scripts/engine.lua
+++ b/scripts/engine.lua
@@ -170,3 +170,12 @@ end
 -- -----
 -- END Pathing: moving interest fix
 -- -----
+
+local oldemitSound = simengine.emitSound
+function simengine:emitSound(sound, x0, y0, unit, ...)
+	if unit and unit:getTraits().cryBaby then
+		sound.ignoreSight = true
+	end
+	oldemitSound(self, sound, x0, y0, unit, ...)
+end
+

--- a/scripts/engine.lua
+++ b/scripts/engine.lua
@@ -171,11 +171,3 @@ end
 -- END Pathing: moving interest fix
 -- -----
 
-local oldemitSound = simengine.emitSound
-function simengine:emitSound(sound, x0, y0, unit, ...)
-	if unit and unit:getTraits().cryBaby then
-		sound.ignoreSight = true
-	end
-	oldemitSound(self, sound, x0, y0, unit, ...)
-end
-

--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -26,6 +26,8 @@ local function earlyInit(modApi)
         -- Talkative Agents adds event handlers to mission_panel:processEvent in lateInit.
         "Talkative Agents",
     }
+
+    include(modApi:getScriptPath() .. "/senses_earlyInit")
 end
 
 local function init(modApi)

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -1,0 +1,69 @@
+local Senses = include("sim/btree/senses")
+local simquery = include("sim/simquery")
+local mathutil = include("modules/mathutil")
+local simdefs = include("sim/simdefs")
+
+function Senses:processInterestShared(sim, evData)
+	if evData.range and mathutil.dist2d(evData.x, evData.y, self.unit:getLocation()) > evData.range then
+		return
+	end
+
+	if evData.interest.sourceUnit == self.unit then
+		return
+	end
+
+	if evData.target then
+		if self:hasTarget(evData.target) or self.currentTarget then
+			return
+		end
+
+		if
+			simquery.couldUnitSee(sim, self.unit, evData.target)
+			-- new: instead of only raycast, also check if interest cell is in vision range.
+			-- (simquery.couldUnitSeeCell does both)
+			and simquery.couldUnitSeeCell(sim, self.unit, sim:getCell(evData.interest.x, evData.interest.y))
+		then
+			self:addTarget(evData.target)
+			return
+		end
+	end
+	self:addInterest(
+		evData.interest.x,
+		evData.interest.y,
+		simdefs.SENSE_RADIO,
+		evData.interest.reason or simdefs.REASON_SHARED,
+		evData.interest.sourceUnit
+	)
+end
+
+function Senses:processSoundTrigger(sim, evData)
+	if evData.sourceUnit and evData.sourceUnit:getPlayerOwner() == self.unit:getPlayerOwner() then
+		return
+	end
+
+	if not self.unit:getTraits().hasHearing then
+		return
+	end
+
+	if
+		evData.sourceUnit
+		and sim:canUnitSeeUnit(self.unit, evData.sourceUnit)
+		-- check if we can actually react to the target (crybaby passes the checks before this)
+		-- optimally would just check for evData.ignoreSight but nobody uses this
+		and simquery.isEnemyTarget(self.unit:getPlayerOwner(), evData.sourceUnit)
+	then
+		return
+	end
+
+	if sim:canUnitSee(self.unit, evData.x, evData.y) and evData.ignoreSight == nil then
+		if self.unit:getTraits().seesHidden or not simquery.checkCover(sim, self.unit, evData.x, evData.y) then
+			return
+		end
+	end
+
+	if mathutil.dist2d(evData.x, evData.y, self.unit:getLocation()) > evData.range then
+		return
+	end
+
+	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
+end

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -21,7 +21,8 @@ function Senses:processInterestShared(sim, evData)
 			simquery.couldUnitSee(sim, self.unit, evData.target)
 			-- new: instead of only raycast, also check if interest cell is in vision range.
 			-- (simquery.couldUnitSeeCell does both)
-			and simquery.couldUnitSeeCell(sim, self.unit, sim:getCell(evData.interest.x, evData.interest.y))
+			and evData.target:getLocation()
+			and simquery.couldUnitSeeCell(sim, self.unit, sim:getCell(evData.target:getLocation()))
 		then
 			self:addTarget(evData.target)
 			return
@@ -67,3 +68,4 @@ function Senses:processSoundTrigger(sim, evData)
 
 	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
 end
+

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -56,6 +56,7 @@ function Senses:processSoundTrigger(sim, evData)
 			sim:canUnitSee(self.unit, evData.x, evData.y)
 			and (self.unit:getTraits().seesHidden or not simquery.checkCover(sim, self.unit, evData.x, evData.y))
 		then
+			return
 		end
 	end
 
@@ -65,6 +66,7 @@ function Senses:processSoundTrigger(sim, evData)
 
 	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
 end
+
 
 
 

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -21,7 +21,6 @@ function Senses:processInterestShared(sim, evData)
 			simquery.couldUnitSee(sim, self.unit, evData.target)
 			-- new: instead of only raycast, also check if interest cell is in vision range.
 			-- (simquery.couldUnitSeeCell does both)
-			and evData.target:getLocation()
 			and simquery.couldUnitSeeCell(sim, self.unit, sim:getCell(evData.target:getLocation()))
 		then
 			self:addTarget(evData.target)
@@ -66,6 +65,7 @@ function Senses:processSoundTrigger(sim, evData)
 
 	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
 end
+
 
 
 

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -46,6 +46,7 @@ function Senses:processSoundTrigger(sim, evData)
 		return
 	end
 
+	-- moved canSee sourceUnit check inside ignoreSight condition
 	if evData.ignoreSight == nil then
 		if evData.sourceUnit and sim:canUnitSeeUnit(self.unit, evData.sourceUnit) then
 			return
@@ -64,5 +65,6 @@ function Senses:processSoundTrigger(sim, evData)
 
 	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
 end
+
 
 

--- a/scripts/senses_earlyInit.lua
+++ b/scripts/senses_earlyInit.lua
@@ -46,19 +46,15 @@ function Senses:processSoundTrigger(sim, evData)
 		return
 	end
 
-	if
-		evData.sourceUnit
-		and sim:canUnitSeeUnit(self.unit, evData.sourceUnit)
-		-- check if we can actually react to the target (crybaby passes the checks before this)
-		-- optimally would just check for evData.ignoreSight but nobody uses this
-		and simquery.isEnemyTarget(self.unit:getPlayerOwner(), evData.sourceUnit)
-	then
-		return
-	end
-
-	if sim:canUnitSee(self.unit, evData.x, evData.y) and evData.ignoreSight == nil then
-		if self.unit:getTraits().seesHidden or not simquery.checkCover(sim, self.unit, evData.x, evData.y) then
+	if evData.ignoreSight == nil then
+		if evData.sourceUnit and sim:canUnitSeeUnit(self.unit, evData.sourceUnit) then
 			return
+		end
+
+		if
+			sim:canUnitSee(self.unit, evData.x, evData.y)
+			and (self.unit:getTraits().seesHidden or not simquery.checkCover(sim, self.unit, evData.x, evData.y))
+		then
 		end
 	end
 
@@ -68,4 +64,5 @@ function Senses:processSoundTrigger(sim, evData)
 
 	self:addInterest(evData.x, evData.y, simdefs.SENSE_HEARING, simdefs.REASON_NOISE, evData.sourceUnit)
 end
+
 


### PR DESCRIPTION
**Fix #52**
Not much to say here. We just add the missing vision range check in ``senses.processInterestShared``.

**Fix guards ignoring Crybaby if they can see it**
* Expanded ``evData.ignoreSight == nil`` check so sourceUnits also do not prevent reactions when ``ignoreSight`` is set
* ~~Append ``sim:emitSound`` to add ``ignoreSight`` to crybaby (otherwise messy override, also FL already overrides it)~~

I put both fixes into ``earlyInit`` because they are hard overrides with no calls to the original function. It's easier for other mods to append the overriden functions that way. But from what I could tell, no other mod currently appends these.

Edit: I removed the crybaby change since I think it does make some sense that guards don't react to a sound coming from a cell they can already see. I still think the description/tooltip should implicate this but I don't think it's necessarily a bug anymore