### PR TITLE
simquery.isUnitUnderOverwatch fix

### DIFF
--- a/scripts/engine.lua
+++ b/scripts/engine.lua
@@ -170,3 +170,13 @@ end
 -- -----
 -- END Pathing: moving interest fix
 -- -----
+
+-- this prevents a hard crash from client side later with a traceback that's impossible to know where the event came from
+local dispatchEvent = simengine.dispatchEvent
+simengine.dispatchEvent = function(self, evType, evData, ...)
+	if evType == simdefs.EV_UNIT_FLOAT_TXT then
+		assert(evData.txt)
+	end
+	return dispatchEvent(self, evType, evData, ...)
+end
+

--- a/scripts/simquery.lua
+++ b/scripts/simquery.lua
@@ -61,3 +61,25 @@ function simquery.canSoftPath(sim, unit, startcell, endcell, ...)
 
     return simquery.canStaticPath(sim, unit, startcell, endcell)
 end
+
+-- this mistakenly returned true on a target if it leaves overwatch but the guard had multiple targets before
+-- (there is no cleanup in the combat situation until the guard leaves combat)
+function simquery.isUnitUnderOverwatch(target)
+	local aiPlayer = target:getSim() and target:getSim():getNPC()
+	local situation = aiPlayer and aiPlayer:findExistingCombatSituation(target)
+	if situation and situation:isValid() then
+		for k, unit in pairs(situation.units) do
+			if
+				not unit:isDown()
+				and not unit:getTraits().pacifist
+                -- check if the unit actually still has this target
+				and unit:getBrain()
+				and unit:getBrain():getSenses()
+				and unit:getBrain():getSenses():hasTarget(target)
+			then
+				return true
+			end
+		end
+	end
+	return false
+end


### PR DESCRIPTION
If you've ever noticed why some agents are still in their "melee/overwatched" pose even though they've left overwatch, this is why.

Unrelated: I also had two instances of mods causing a hard crash because of a dispatched EV_UNIT_FLOAT_TXT without a txt, which is impossible to debug via the log because the sim dispatch is not in the traceback when processing the event in the client. So I suggest putting an assert in there to prevent both the crash and the debugging issues.