### PR TITLE
Fix TRG_LOS_REFRESH not firing correctly for hacks

### DIFF
--- a/scripts/simunit.lua
+++ b/scripts/simunit.lua
@@ -115,6 +115,18 @@ rawset(
             end
         end)
 
+-- fix mission hooks not firing when spotting cell tags via hacking a camera
+local oldSetPlayerOwner = simunit.setPlayerOwner
+simunit.setPlayerOwner = function(self, player, ...)
+	local oldOwner = self._parent
+	oldSetPlayerOwner(self, player, ...)
+	if self:isValid() and oldOwner and self._parent ~= oldOwner and self._parent == player then
+		local cells = {}
+		self:getSim():getLOS():getVizCells(self:getID(), cells)
+		self:getSim():triggerEvent(simdefs.TRG_LOS_REFRESH, { seer = self, cells = cells })
+	end
+end
+
 local oldAddTag = simunit.addTag
 function simunit:addTag(tag, ...)
     if self:getUnitData().id == "data_card" and tag == "access_card_obj" then

--- a/scripts/simunit.lua
+++ b/scripts/simunit.lua
@@ -120,7 +120,7 @@ local oldSetPlayerOwner = simunit.setPlayerOwner
 simunit.setPlayerOwner = function(self, player, ...)
 	local oldOwner = self._parent
 	oldSetPlayerOwner(self, player, ...)
-	if self:isValid() and oldOwner and self._parent ~= oldOwner and self._parent == player then
+	if self:isValid() and oldOwner and self._parent and self._parent ~= oldOwner and self._parent == player then
 		local cells = {}
 		self:getSim():getLOS():getVizCells(self:getID(), cells)
 		self:getSim():triggerEvent(simdefs.TRG_LOS_REFRESH, { seer = self, cells = cells })


### PR DESCRIPTION
On Luna's stream, twice now the my script hooks from Facility Flux for spotting a special prefab (e.g. Strongroom, Teleporter) have not been triggered because she spotted them by hacking a camera. That made me notice that only MM has the fix for that, and Luna doesn't have MM installed.

We should move this fix to CBF (MM requires it anway). Also, it shouldn't recalculate the unit's vision - we can just read the unit's marked vision from the LOSMap. (I chose to append ``simunit.setPlayerOwner`` instead of ``simplayer.onUnitAdded`` to not have to deal with include order shenanigans of class inheritance)