### PR TITLE
Fix aiplayer cleanup coming too late

### DIFF
--- a/scripts/simplayer.lua
+++ b/scripts/simplayer.lua
@@ -21,6 +21,15 @@ local oldOnStartTurn = simplayer.onStartTurn
 
 -- Overwrite simplayer:onStartTurn. Changes at "CBF:"
 function simplayer:onStartTurn(sim, ...)
+    -- fix aiplayer cleanup coming too late (simunit.onStartTurn can call tickKO which
+    -- processes reactions before TRG_START_TURN is even triggered)
+	for _, unit in ipairs(sim:getNPC():getUnits()) do
+		if unit:getBrain() then
+			unit:getBrain():getSenses():clearIgnoredInterests()
+			unit:getBrain():getSenses():clearLostTargets()
+		end
+	end
+    
     local fixCycleTiming = cbf_util.simCheckFlag(sim, "cbf_cycletiming")
     if fixCycleTiming then
         -- CBF: Move this clause before all unit:onStartTurn calls, instead of after.


### PR DESCRIPTION
https://discord.com/channels/313015356052471828/313015598789427202/1350735695626633266
In addition to the bug you already explained in the link, I had multiple instances of one of my Threat Spectrum guards that moves while having a target (thus spawning lost target interests) shoots a player at the start of PC turn because something has processed reactions before aiplayer cleaned up the lost targets.

My first fix was changing the priority of the aiplayer trigger, but then I had the bug still appear because player- and simunit:onStartTurn are called before that. It needs to be called at the very start of player:onStartTurn to always be first.