### PR TITLE
Fix anarchy bonus not showing on corpses

### DIFF
--- a/scripts/items_panel.lua
+++ b/scripts/items_panel.lua
@@ -25,11 +25,7 @@ end
 
 function loot_panel:refreshItem(widget, i, ...)
     local wasGuard = self._targetUnit:getTraits().isGuard
-	if
-		self._targetUnit:getTraits().iscorpse
-		and self._targetUnit:getTraits().unitID
-		and self._hud._game.simCore._resultTable.guards[self._targetUnit:getTraits().unitID]
-	then
+	if self._targetUnit:getTraits().cashOnHand then
 		self._targetUnit:getTraits().isGuard = true
 	end
     local res = oldLootRefreshItem(self, widget, i, ...)

--- a/scripts/items_panel.lua
+++ b/scripts/items_panel.lua
@@ -24,7 +24,16 @@ local function getCarryableItemByIndex(unit, targetUnit, i)
 end
 
 function loot_panel:refreshItem(widget, i, ...)
+    local wasGuard = self._targetUnit:getTraits().isGuard
+	if
+		self._targetUnit:getTraits().iscorpse
+		and self._targetUnit:getTraits().unitID
+		and self._hud._game.simCore._resultTable.guards[self._targetUnit:getTraits().unitID]
+	then
+		self._targetUnit:getTraits().isGuard = true
+	end
     local res = oldLootRefreshItem(self, widget, i, ...)
+    self._targetUnit:getTraits().isGuard = wasGuard
 
     if res and cbf_util.simCheckFlag(self._hud._game.simCore, "cbf_ending_incognitadrop") then
         local item = getCarryableItemByIndex(self._unit, self._targetUnit, i)


### PR DESCRIPTION
Fix #68 
Kind of ugly but give corpse the isGuard trait only during loot panel update if the guard is registered in the guard result table since it needs that to calculate the bonus