### PR TITLE
Add mod footer to programs in stores

### DIFF
--- a/scripts/modinit.lua
+++ b/scripts/modinit.lua
@@ -145,6 +145,7 @@ local function init(modApi)
     include(scriptPath .. "/units/cbf_smoke_edge")
     include(scriptPath .. "/units/simdisguiseitem")
     include(scriptPath .. "/units/smoke_cloud")
+    include(scriptPath .. "/units/store")
     include(scriptPath .. "/missions/mission_util")
     include(scriptPath .. "/procgen")
 

--- a/scripts/units/store.lua
+++ b/scripts/units/store.lua
@@ -1,0 +1,23 @@
+local store = include("sim/units/store")
+local mainframe_abilities = include("sim/abilities/mainframe_abilities")
+
+local createProgramUnitData = store.createProgramUnitData
+store.createProgramUnitData = function(abilityName, sim, ...)
+	local unitData = createProgramUnitData(abilityName, sim, ...)
+	local abilityDef = mainframe_abilities[abilityName]
+	local onTooltip = unitData.onTooltip
+	unitData.onTooltip = function(tooltip, unit, ...)
+		onTooltip(tooltip, unit, ...)
+		if abilityDef.dlcFooter then
+			tooltip:addFooter(abilityDef.dlcFooter[1], abilityDef.dlcFooter[2])
+		end
+	end
+	return unitData
+end
+
+-- only necessary when playing without function library - it already makes store.createStoreItems use the createProgramUnitData
+-- from the store table instead of the local upvalue. it's fine, in that case we just don't find the upvalue and bail out.
+local _, idx, subFn = upvalueUtil.find(store.createStoreItems, "createProgramUnitData", 5)
+if idx then
+	debug.setupvalue(subFn, idx, store.createProgramUnitData)
+end


### PR DESCRIPTION
Vanilla forgot to add the dlc footers in store.createProgramUnitData, so the unitified programs in the shopcat selection don't have a mod footer, while the programs itself do have them.

The fix is to just append both that function and the tooltip of the returned unitData with the mod footer.