### PR TITLE
Fix simquery.couldUnitSeeCell being inaccurate for unit vision

### DIFF
--- a/scripts/line_of_sight.lua
+++ b/scripts/line_of_sight.lua
@@ -61,3 +61,37 @@ function line_of_sight:calculateUnitLOS(start_cell, unit, ...)
 
     return cells
 end
+
+-- the simple raycast the game often uses for LOS check is not precise for unit vision
+
+-- most commonly, it doesn't reach cells that the unit can actually see when accounting for partial visibility (>= 0.45)
+
+-- but there are also rare cases where this partial visibility threshold is too high and the raycast can give a false positive (< 0.45)
+-- (this is most problematic with simquery.couldUnitSeeCell as it can cause guards to target an agent by
+-- senses:processInterestShared even though they can't see the agent)
+
+local raycast = line_of_sight.raycast
+line_of_sight.raycast = function(self, x0, y0, x1, y1, ...)
+	-- I don't think this takes any extra parameters but who knows
+	if select("#", ...) > 0 then
+		return raycast(self, x0, y0, x1, y1, ...)
+	end
+
+	if self:raycastToCell(x0, y0, x1, y1, 0, math.pi) then
+		return x1, y1
+	end
+
+	local raycastX, raycastY = raycast(self, x0, y0, x1, y1)
+
+	if raycastX == x1 and raycastY == y1 then
+		-- need to return something different than the exact position, so move a tiny distance back in the general ray direction
+		if x0 ~= x1 then
+			raycastX = x1 + (x0 < x1 and -0.001 or 0.001)
+		end
+		if y0 ~= y1 then
+			raycastY = y1 + (y0 < y1 and -0.001 or 0.001)
+		end
+	end
+
+	return raycastX, raycastY
+end

--- a/scripts/line_of_sight.lua
+++ b/scripts/line_of_sight.lua
@@ -61,37 +61,3 @@ function line_of_sight:calculateUnitLOS(start_cell, unit, ...)
 
     return cells
 end
-
--- the simple raycast the game often uses for LOS check is not precise for unit vision
-
--- most commonly, it doesn't reach cells that the unit can actually see when accounting for partial visibility (>= 0.45)
-
--- but there are also rare cases where this partial visibility threshold is too high and the raycast can give a false positive (< 0.45)
--- (this is most problematic with simquery.couldUnitSeeCell as it can cause guards to target an agent by
--- senses:processInterestShared even though they can't see the agent)
-
-local raycast = line_of_sight.raycast
-line_of_sight.raycast = function(self, x0, y0, x1, y1, ...)
-	-- I don't think this takes any extra parameters but who knows
-	if select("#", ...) > 0 then
-		return raycast(self, x0, y0, x1, y1, ...)
-	end
-
-	if self:raycastToCell(x0, y0, x1, y1, 0, math.pi) then
-		return x1, y1
-	end
-
-	local raycastX, raycastY = raycast(self, x0, y0, x1, y1)
-
-	if raycastX == x1 and raycastY == y1 then
-		-- need to return something different than the exact position, so move a tiny distance back in the general ray direction
-		if x0 ~= x1 then
-			raycastX = x1 + (x0 < x1 and -0.001 or 0.001)
-		end
-		if y0 ~= y1 then
-			raycastY = y1 + (y0 < y1 and -0.001 or 0.001)
-		end
-	end
-
-	return raycastX, raycastY
-end

--- a/scripts/simquery.lua
+++ b/scripts/simquery.lua
@@ -78,3 +78,10 @@ function simquery.isUnitUnderOverwatch(target)
     end
     return false
 end
+
+function simquery.couldUnitSeeCell(sim, unit, cell)
+	local ux, uy = unit:getLocation()
+	-- should work with infinite vision range at LOSrange == nil
+	return sim:getLOS():raycastToCell(ux, uy, cell.x, cell.y, 0, math.pi, unit:getTraits().LOSrange)
+end
+


### PR DESCRIPTION
The LOS raycast the game uses to make a sight line check does not use the >= 0.45 vision sample rule that the regular unit vision does and only checks if the exact middle of a cell reaches the exact middle of another cell. This causes several bugs that happen when code confidently assumes that a unit has vision or not because of what the raycast returns. ``simquery.couldUnitSeeCell`` most notably causes issues here, since this is what guard code uses to check, for example, if a guard should target an agent without being turned to the agent yet.

A very regular occurrence of the difference between unit vision and raycast returns is an agent trying to throw something in their vision, but can't, because raycast says no even though their vision says yes:
<img width="1487" height="742" alt="raycast" src="https://github.com/user-attachments/assets/ff400467-db49-4e5e-98bd-248dd47251ec" />
I assume this is done for the logical reason that you can't throw anything around corners so a direct raycast from the middle of the cell to the other cell is required, but the actual difference in the end result is niche enough that I don't think it's a problem to change this.
(Edit: On second thought, having a raycast as requirement instead of current vision for the throw is probably not for realism but with guards in mind because you can't check their current vision for tiles outside of it and for grenade throws in the path calculation.)

A less common occurrence is the raycast returning the end coordinates even though there are < 0.45 vision samples:
<img width="1570" height="651" alt="raycast3" src="https://github.com/user-attachments/assets/6a394cc4-32ec-42a2-8b98-7c522dbb9bd3" />
<img width="1511" height="735" alt="raycast2" src="https://github.com/user-attachments/assets/b8ad7fd2-6fde-42b9-95a5-234c5052cd96" />
Here you can see that Sader does not actually have vision of this cell or this guard (it's a unit ghost which isn't obvious in tactical view), but she is able to throw to this tile. She is even able to use her knockback ability on the guard without seeing the guard, though I guess that's more of a problem (if it even is a problem at all) with how Mobbstar coded it.

~~I do think that this difference is causing more problems than whatever realism positives it might add, especially with mods making heavier and maybe less careful use of this than vanilla.
That's why my approach is to override ``line_of_sight:raycast`` to synchronize it with the unit raycast using the >= 0.45 vision samples threshold.~~
But I can also see an argument for only overriding ``simquery.canUnitSeeCell``, since that is where it really makes no sense to use the normal raycast because we clearly care about what actual unit vision would be like here. At least in vanilla, I don't see other functions using this in a problematic way. It is worth noting that changing the raycast will also slightly alter which cells drones scan and EMPs reach around obstructions.

Edit: I changed my mind about overriding the raycast, it feels too intrusive to vanilla with throwable objects flying through corners and scans being expanded. Keeping the override to ``simquery.couldUnitSeeCell`` is better in my opinion.